### PR TITLE
Add auto waiting vote support and walletServer run start foreground

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdkVersion 29
     buildToolsVersion "29.0.2"
     defaultConfig {
-        applicationId "com.xcash.wallet2"
+        applicationId "com.xcash.wallet"
         minSdkVersion 17
         targetSdkVersion 26
         versionCode 1

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdkVersion 29
     buildToolsVersion "29.0.2"
     defaultConfig {
-        applicationId "com.xcash.wallet"
+        applicationId "com.xcash.wallet2"
         minSdkVersion 17
         targetSdkVersion 26
         versionCode 1

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
 
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <permission android:name="com.xcash.wallet.aidl.permission.LOCAL" />
     <uses-permission android:name="com.xcash.wallet.aidl.permission.LOCAL" />

--- a/app/src/main/java/com/xcash/base/utils/TimeTool.java
+++ b/app/src/main/java/com/xcash/base/utils/TimeTool.java
@@ -15,7 +15,11 @@
  */
 package com.xcash.base.utils;
 
-public class TimeTool {
+ import java.text.SimpleDateFormat;
+ import java.util.Date;
+ import java.util.TimeZone;
+
+ public class TimeTool {
 
     private static long oldTime = -1;
     private static int count = 0;
@@ -50,5 +54,12 @@ public class TimeTool {
         time = time * ratio + count;
         return time;
     }
+
+    public static String getUtcTime() {
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm");
+        simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return simpleDateFormat.format(new Date());
+    }
+
 
 }

--- a/app/src/main/java/com/xcash/utils/NotificationHelper.java
+++ b/app/src/main/java/com/xcash/utils/NotificationHelper.java
@@ -21,12 +21,14 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.ContextWrapper;
+import android.content.Intent;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.os.Build;
 
 import androidx.core.app.NotificationCompat;
 
+import com.xcash.wallet.MainActivity;
 import com.xcash.wallet.R;
 
 
@@ -121,4 +123,12 @@ public class NotificationHelper extends ContextWrapper {
         getNotificationManager().notify(notifyId, builder.build());
     }
 
+    public static PendingIntent getDefaultPendingIntent(Context context){
+        Intent intent = new Intent(context, MainActivity.class);
+        intent.setAction(Intent.ACTION_MAIN);
+        intent.addCategory(Intent.CATEGORY_LAUNCHER);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.addFlags(Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+        return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+    }
 }

--- a/app/src/main/java/com/xcash/utils/WalletServiceHelper.java
+++ b/app/src/main/java/com/xcash/utils/WalletServiceHelper.java
@@ -267,10 +267,10 @@ public class WalletServiceHelper {
                     handler.post(new Runnable() {
                         @Override
                         public void run() {
+                            showNotification(tips+" "+value);
                             if(onVoteListener!=null) {
                                 onVoteListener.onSuccess(tips);
                             }
-                            BaseActivity.showShortToast(context, tips);
                         }
                     });
                 }
@@ -281,10 +281,10 @@ public class WalletServiceHelper {
                     handler.post(new Runnable() {
                         @Override
                         public void run() {
+                            showNotification(context.getString(R.string.activity_dpops_vote_failed_tips)+" "+value);
                             if(onVoteListener!=null) {
                                 onVoteListener.onError(error);
                             }
-                            BaseActivity.showShortToast(context, context.getString(R.string.activity_dpops_vote_failed_tips));
                         }
                     });
                 }
@@ -300,8 +300,7 @@ public class WalletServiceHelper {
     public void waitToVote(Context context,final String value,long delayMillis,boolean showNotification,final OnVoteListener onVoteListener){
         if(showNotification){
             String content = context.getString(R.string.waiting_to_vote_tips)+" "+value;
-            notificationId = notificationId + 1;
-            notificationHelper.sendNotification(notificationId, context.getString(R.string.app_name), content, NotificationHelper.getDefaultPendingIntent(context));
+            showNotification(content);
         }
         voteHandler.removeCallbacksAndMessages(null);
         voteHandler.postDelayed(new Runnable() {
@@ -310,6 +309,11 @@ public class WalletServiceHelper {
                 doVote(value,onVoteListener);
             }
         },delayMillis);
+    }
+
+    public void showNotification(String content){
+        notificationId = notificationId + 1;
+        notificationHelper.sendNotification(notificationId, context.getString(R.string.app_name), content, NotificationHelper.getDefaultPendingIntent(context));
     }
 
     /**
@@ -460,8 +464,7 @@ public class WalletServiceHelper {
         private void receiveNotfication(int walletId, String txId, long amount) {
             try {
                 String content = context.getString(R.string.start_receive_transaction_notfication_tips) + String.valueOf(amount / 1000000.0f) + " " + XManager.SYMBOL;
-                notificationId = notificationId + 1;
-                notificationHelper.sendNotification(notificationId, context.getString(R.string.app_name), content, NotificationHelper.getDefaultPendingIntent(context));
+                showNotification(content);
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/app/src/main/java/com/xcash/utils/WalletServiceHelper.java
+++ b/app/src/main/java/com/xcash/utils/WalletServiceHelper.java
@@ -267,7 +267,9 @@ public class WalletServiceHelper {
                     handler.post(new Runnable() {
                         @Override
                         public void run() {
-                            showNotification(tips+" "+value);
+                            String content=tips+"=>"+value;
+                            showNotification(content);
+                            BaseActivity.showLongToast(context, content);
                             if(onVoteListener!=null) {
                                 onVoteListener.onSuccess(tips);
                             }
@@ -281,7 +283,9 @@ public class WalletServiceHelper {
                     handler.post(new Runnable() {
                         @Override
                         public void run() {
-                            showNotification(context.getString(R.string.activity_dpops_vote_failed_tips)+" "+value);
+                            String content=context.getString(R.string.activity_dpops_vote_failed_tips)+"=>"+value;
+                            showNotification(content);
+                            BaseActivity.showLongToast(context, content);
                             if(onVoteListener!=null) {
                                 onVoteListener.onError(error);
                             }

--- a/app/src/main/java/com/xcash/wallet/DpopsActivity.java
+++ b/app/src/main/java/com/xcash/wallet/DpopsActivity.java
@@ -386,13 +386,13 @@ public class DpopsActivity extends NewBaseActivity {
         }
 
         Calendar calendar = Calendar.getInstance();
-        int  minute=  calendar.get(Calendar.MINUTE);
+        int minute=calendar.get(Calendar.MINUTE);
         int waitMinute=0;
-        if(minute>3){
-            waitMinute=60+1-minute;
+        if(minute>=4){
+            waitMinute=60+2-minute;
         }else{
-            if (minute<1){
-                waitMinute=1;
+            if (minute<2){
+                waitMinute=2-minute;
             }
         }
         final long delayMillis=waitMinute*60*1000;

--- a/app/src/main/java/com/xcash/wallet/DpopsActivity.java
+++ b/app/src/main/java/com/xcash/wallet/DpopsActivity.java
@@ -387,15 +387,19 @@ public class DpopsActivity extends NewBaseActivity {
 
         Calendar calendar = Calendar.getInstance();
         int minute=calendar.get(Calendar.MINUTE);
+        int second=calendar.get(Calendar.SECOND);
         int waitMinute=0;
         if(minute>=4){
             waitMinute=60+2-minute;
         }else{
             if (minute<2){
                 waitMinute=2-minute;
+            }else{
+                waitMinute=0;
+                second=0;
             }
         }
-        final long delayMillis=waitMinute*60*1000;
+        final long delayMillis=waitMinute*60*1000-second*1000;
         final String voteTips=getString(R.string.activity_dpops_waiting_vote_tips)+" "+waitMinute+" "+getString(R.string.activity_dpops_waiting_vote_minute_tips);
         PopupWindowHelp.showPopupWindowCustomTips(DpopsActivity.this, view.getRootView(), view, new PopupWindowHelp.OnShowPopupWindowCustomTipsListener() {
             @Override

--- a/app/src/main/java/com/xcash/wallet/DpopsRegisterActivity.java
+++ b/app/src/main/java/com/xcash/wallet/DpopsRegisterActivity.java
@@ -32,6 +32,7 @@ import android.widget.TextView;
 import androidx.core.content.ContextCompat;
 
 import com.xcash.base.BaseActivity;
+import com.xcash.utils.WalletServiceHelper;
 import com.xcash.utils.database.entity.Wallet;
 import com.xcash.wallet.aidl.OnNormalListener;
 import com.xcash.wallet.aidl.WalletOperateManager;
@@ -207,7 +208,7 @@ public class DpopsRegisterActivity extends NewBaseActivity {
             walletOperateManager.delegateRegister(delegateName, delegateIPAddress, blockVerifierMessagesPublicKey, new OnNormalListener.Stub() {
                 @Override
                 public void onSuccess(final String tips) throws RemoteException {
-                    DpopsActivity.addOperationHistory(wallet.getId(), "Delegate Register", true, content + tips);
+                    WalletServiceHelper.addOperationHistory(wallet.getId(), "Delegate Register", true, content + tips);
                     handler.post(new Runnable() {
                         @Override
                         public void run() {
@@ -220,7 +221,7 @@ public class DpopsRegisterActivity extends NewBaseActivity {
 
                 @Override
                 public void onError(final String error) throws RemoteException {
-                    DpopsActivity.addOperationHistory(wallet.getId(), "Delegate Register", false, content + error);
+                    WalletServiceHelper.addOperationHistory(wallet.getId(), "Delegate Register", false, content + error);
                     handler.post(new Runnable() {
                         @Override
                         public void run() {

--- a/app/src/main/java/com/xcash/wallet/DpopsUpdateActivity.java
+++ b/app/src/main/java/com/xcash/wallet/DpopsUpdateActivity.java
@@ -35,6 +35,7 @@ import androidx.core.content.ContextCompat;
 
 import com.xcash.base.BaseActivity;
 import com.xcash.models.local.KeyValueItem;
+import com.xcash.utils.WalletServiceHelper;
 import com.xcash.utils.database.entity.Wallet;
 import com.xcash.wallet.aidl.OnNormalListener;
 import com.xcash.wallet.aidl.WalletOperateManager;
@@ -227,7 +228,7 @@ public class DpopsUpdateActivity extends NewBaseActivity {
             walletOperateManager.delegateUpdate(item, value, new OnNormalListener.Stub() {
                 @Override
                 public void onSuccess(final String tips) throws RemoteException {
-                    DpopsActivity.addOperationHistory(wallet.getId(), "Delegate Update", true, content + tips);
+                    WalletServiceHelper.addOperationHistory(wallet.getId(), "Delegate Update", true, content + tips);
                     handler.post(new Runnable() {
                         @Override
                         public void run() {
@@ -240,7 +241,7 @@ public class DpopsUpdateActivity extends NewBaseActivity {
 
                 @Override
                 public void onError(final String error) throws RemoteException {
-                    DpopsActivity.addOperationHistory(wallet.getId(), "Delegate Update", false, content + error);
+                    WalletServiceHelper.addOperationHistory(wallet.getId(), "Delegate Update", false, content + error);
                     handler.post(new Runnable() {
                         @Override
                         public void run() {

--- a/app/src/main/java/com/xcash/wallet/TheApplication.java
+++ b/app/src/main/java/com/xcash/wallet/TheApplication.java
@@ -54,7 +54,7 @@ public class TheApplication extends Application {
     public static final String SETTING_LASTFILENAME = "setting.txt";
     public static final int AUTOREFRESHDELAY = 350;
     public static final int DEFAULT_SQLDELAY = 350;
-    public static final int DEFAULT_WALLETOPERATEDELAY = 500;
+    public static final int DEFAULT_WALLETOPERATEDELAY = 350;
 
 
     private static TheApplication theApplication;

--- a/app/src/main/java/com/xcash/wallet/uihelp/PopupWindowHelp.java
+++ b/app/src/main/java/com/xcash/wallet/uihelp/PopupWindowHelp.java
@@ -156,6 +156,60 @@ public class PopupWindowHelp {
         baseActivity.addPopupWindow(popupWindowKey, popupWindow);
     }
 
+    public interface OnShowPopupWindowCustomTipsListener {
+
+        void initView(PopupWindow popupWindow, TextView textViewTips,TextView textViewLeft,TextView textViewRight);
+
+    }
+
+    public static void showPopupWindowCustomTips(final BaseActivity baseActivity, View view, final View needEnableView, final OnShowPopupWindowCustomTipsListener onShowPopupWindowCustomTipsListener) {
+        if (view.getWindowToken() == null) {
+            BaseActivity.showSystemErrorLog(WINDOWTOKENISNULL);
+            return;
+        }
+        if (needEnableView != null) {
+            needEnableView.setEnabled(false);
+        }
+        LayoutInflater layoutInflater = baseActivity.getLayoutInflater();
+        View popupWindowView = layoutInflater.inflate(R.layout.popupwindow_normal_tips, null);
+        int popupwindow_horizontal_margin = baseActivity.getResources().getDimensionPixelSize(
+                R.dimen.popupwindow_horizontal_margin);
+        int popupWindowWidth = BaseActivity.getScreenWidth(baseActivity) - popupwindow_horizontal_margin * 2;
+        final String popupWindowKey = POPUPWINDOWKEY + TimeTool.getOnlyTimeWithoutSleep();
+        final PopupWindow popupWindow = new PopupWindow(popupWindowView, popupWindowWidth, ViewGroup.LayoutParams.WRAP_CONTENT);
+        popupWindow.setOnDismissListener(new PopupWindow.OnDismissListener() {
+            @Override
+            public void onDismiss() {
+                WindowManager.LayoutParams windowManagerLayoutParams = baseActivity.getWindow().getAttributes();
+                windowManagerLayoutParams.alpha = 1.0f;
+                baseActivity.getWindow().setAttributes(windowManagerLayoutParams);
+                if (needEnableView != null) {
+                    needEnableView.setEnabled(true);
+                }
+                baseActivity.removePopupWindow(popupWindowKey);
+            }
+        });
+        final TextView textViewTips = (TextView) popupWindowView.findViewById(R.id.textViewTips);
+        final TextView textViewCancel = (TextView) popupWindowView.findViewById(R.id.textViewCancel);
+        final TextView textViewOK = (TextView) popupWindowView.findViewById(R.id.textViewOK);
+        if (onShowPopupWindowCustomTipsListener != null) {
+            onShowPopupWindowCustomTipsListener.initView(popupWindow,textViewTips,textViewCancel,textViewOK);
+        }
+
+        ColorDrawable colorDrawable = new ColorDrawable(Color.argb(0, 255, 255, 255));
+        popupWindow.setBackgroundDrawable(colorDrawable);
+        popupWindow.setFocusable(true);
+        popupWindow.setOutsideTouchable(false);
+        popupWindow.setAnimationStyle(R.style.popwindowNormalAnimationCenter);
+        popupWindow.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
+        WindowManager.LayoutParams windowManagerLayoutParams = baseActivity.getWindow().getAttributes();
+        windowManagerLayoutParams.alpha = 0.7f;
+        baseActivity.getWindow().setAttributes(windowManagerLayoutParams);
+        popupWindow.showAtLocation(view, Gravity.CENTER, 0, 0);
+        baseActivity.addPopupWindow(popupWindowKey, popupWindow);
+    }
+
+
     public interface OnShowPopupWindowPasswordTipsListener {
 
         void okClick(PopupWindow popupWindow, EditText editTextPassword, View view);

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -39,6 +39,8 @@
     <string name="retry_bind_service_tips">绑定服务断开连接，正在尝试重新连接，请稍后再试</string>
     <string name="show_more_tips">显示更多</string>
     <string name="address_error_tips">地址错误</string>
+    <string name="server_run_tips">XCASH服务正在运行!</string>
+    <string name="waiting_to_vote_tips">等待投票给</string>
 
     <string name="popupwindow_textViewOK_text">确定</string>
     <string name="popupwindow_textViewCancel_text">取消</string>
@@ -251,6 +253,10 @@
     <string name="activity_dpops_checkVoteValue_tips">投票内容不能为空</string>
     <string name="activity_dpops_checkUnlockedBalance_tips">可用余额必须大于0</string>
     <string name="activity_dpops_vote_failed_tips">投票给指定代表失败，您可以在历史记录页面中查看信息</string>
+    <string name="activity_dpops_waiting_vote_tips">是否发起投票，预计等待</string>
+    <string name="activity_dpops_waiting_vote_minute_tips">分钟</string>
+    <string name="activity_dpops_auto_waiting_vote_tips">定时投票</string>
+    <string name="activity_dpops_quick_vote_tips">立即投票</string>
 
     <string name="activity_dpops_register_textViewTitle_text">注册代表</string>
     <string name="activity_dpops_register_editTextDelegateName_hint">代表名称</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,8 @@
     <string name="retry_bind_service_tips">Service disconnected, trying to reconnect.. please try gain later</string>
     <string name="show_more_tips">Show More</string>
     <string name="address_error_tips">Error address</string>
+    <string name="server_run_tips">XCASH server is running!</string>
+    <string name="waiting_to_vote_tips">Waiting to vote for</string>
 
     <string name="popupwindow_textViewOK_text">OK</string>
     <string name="popupwindow_textViewCancel_text">Cancel</string>
@@ -251,6 +253,10 @@
     <string name="activity_dpops_checkVoteValue_tips">Vote value cannot be empty</string>
     <string name="activity_dpops_checkUnlockedBalance_tips">Unlocked balance must be greater than 0</string>
     <string name="activity_dpops_vote_failed_tips">Delegate vote failed | You can view the info in the history page</string>
+    <string name="activity_dpops_waiting_vote_tips">Whether to initiate a vote, expected to wait</string>
+    <string name="activity_dpops_waiting_vote_minute_tips">minutes</string>
+    <string name="activity_dpops_auto_waiting_vote_tips">Auto waiting vote</string>
+    <string name="activity_dpops_quick_vote_tips">Quick vote</string>
 
     <string name="activity_dpops_register_textViewTitle_text">Register Delegate</string>
     <string name="activity_dpops_register_editTextDelegateName_hint">Delegate Name</string>


### PR DESCRIPTION
# Description

Add auto waiting vote support and walletServer run start foreground.

1.Support auto waiting vote and quick vote choose,If use auto waiting vote it will waiting vote until every hour between 2~3  minutes,It can help vote more easily.

2.Change wallet server run with start foreground,can help more difficult to recycle by Android System. 

